### PR TITLE
fix: resolve JVM crash on Docker Desktop Cgroup v2 environments

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: quad-server
     env_file:
       - ./env/flexo-mms-quad-store.env
+    environment:
+      JAVA_TOOL_OPTIONS: -XX:-UseContainerSupport
     command: --file=/tmp/mount/cluster.trig --update /ds
     volumes:
       - ./mount:/tmp/mount


### PR DESCRIPTION
**Description:**
I encountered a recurring java.lang.NullPointerException in CgroupV2Subsystem when running the atomgraph/fuseki:4.6 image. This issue specifically affects users running Docker Desktop on Windows/WSL2, as these environments default to the Cgroup v2 hierarchy, which the older JVM version in this image cannot resolve.

**Changes:**
    Added JAVA_TOOL_OPTIONS: -XX:-UseContainerSupport to the quad-store-server service configuration in docker-compose.yml.

**Reasoning:**
This flag explicitly disables the JVM's internal Cgroup detection logic, which prevents the crash during initialization. This allows the service to start correctly on modern container environments while maintaining existing resource configurations.

**Testing:**
    Verified in a local Docker Desktop (WSL2) environment. The service now starts successfully without the previous InternalError.