### PR TITLE
dev: add graphdb support & commit message lost when POST /commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ application.conf
 
 gen
 *-logback.xml
+
+# IDE build output
+bin/

--- a/src/main/kotlin/org/openmbee/flexo/sysmlv2/Namespaces.kt
+++ b/src/main/kotlin/org/openmbee/flexo/sysmlv2/Namespaces.kt
@@ -131,6 +131,7 @@ object MMS {
 
     val commitId = prop("commitId")
     val submitted = prop("submitted")
+    val message = prop("message")
     // access control properties
     val implies = prop("implies")
 

--- a/src/main/kotlin/org/openmbee/flexo/sysmlv2/apis/BranchApi.kt
+++ b/src/main/kotlin/org/openmbee/flexo/sysmlv2/apis/BranchApi.kt
@@ -36,8 +36,9 @@ fun FlexoModelHandler.branchFromResponse(
     outgoing: Map<Property, Set<RDFNode>>,
     projectId: String,
     branchId: String
-): Branch {
-    val commit = Identified(outgoing[MMS.commit]!!.resource()!!.uri.uriSuffix)
+): Branch? {
+    val commitSuffix = outgoing[MMS.commit]?.resource()?.uri?.uriSuffix ?: return null
+    val commit = Identified(commitSuffix)
     return Branch(
         atId = branchId,
         atType = Branch.AtType.Branch,
@@ -73,7 +74,7 @@ fun Route.BranchApi() {
         val branch = patchResponse.parseModel {
             model.listSubjectsWithProperty(RDF.type, MMS.Branch).mapWith {
                 branchFromResponse(it.outgoing(), path.projectId, it.uri.uriSuffix)
-            }.toList().firstOrNull()
+            }.toList().filterNotNull().firstOrNull()
         } ?: return@delete call.respond(HttpStatusCode.NotFound)
         call.respond(branch)
     }
@@ -94,7 +95,7 @@ fun Route.BranchApi() {
                 (it.hasProperty(SYSMLV2.DELETED) || it.uri.uriSuffix == "master")
             }.mapWith {
                 branchFromResponse(it.outgoing(), path.projectId, it.uri.uriSuffix)
-            }.toList()
+            }.toList().filterNotNull()
         })
     }
 
@@ -112,7 +113,7 @@ fun Route.BranchApi() {
         val branch = flexoResponse.parseModel {
             model.listSubjectsWithProperty(RDF.type, MMS.Branch).mapWith {
                 branchFromResponse(it.outgoing(), path.projectId, it.uri.uriSuffix)
-            }.toList().firstOrNull()
+            }.toList().filterNotNull().firstOrNull()
         } ?: return@get call.respond(HttpStatusCode.NotFound)
         call.respond(branch)
     }
@@ -143,6 +144,7 @@ fun Route.BranchApi() {
         }
         call.respond(createBranchResponse.parseLdp {
             branchFromResponse(focalOutgoing, projectId, branchId)
+                ?: throw IllegalStateException("Layer1 did not return mms:commit for newly created branch $branchId")
         })
     }
 }

--- a/src/main/kotlin/org/openmbee/flexo/sysmlv2/apis/CommitApi.kt
+++ b/src/main/kotlin/org/openmbee/flexo/sysmlv2/apis/CommitApi.kt
@@ -47,7 +47,9 @@ fun FlexoModelHandler.commitFromModel(
         atId = commitIri.uriSuffix,
         atType = Commit.AtType.Commit,
         created = OffsetDateTime.parse(properties[MMS.submitted]!!.literal()!!),
-        description = properties[DCTerms.description]?.literal()?: "",
+        // Flexo MMS stores the commit message as mms:message; fall back to
+        // dct:description for forward/backward compatibility.
+        description = properties[MMS.message]?.literal()?: properties[DCTerms.description]?.literal()?: "",
         owningProject = Identified(atId = projectId),
         //previousCommit = properties[MMS.parent]?.map {
         //    Identified(atId = UUID.fromString(it.asResource().uri.uriSuffix))
@@ -292,6 +294,9 @@ fun Route.CommitApi() {
             val flexoResponseUpdate = flexoRequestPost {
                 orgPath("/repos/$projectId/branches/$branchId/update")
 
+                // forward the commit message so layer1 records it (mms:message)
+                addQueryParams("message" to (commit.description ?: ""))
+
                 // construct body payload
                 sparqlUpdate {
                     sparqlUpdateString
@@ -316,6 +321,8 @@ fun Route.CommitApi() {
             """
             val flexoResponseLoad = flexoRequestPut {
                 orgPath("/repos/$projectId/branches/$branchId/graph")
+                // forward the commit message so layer1 records it (mms:message)
+                addQueryParams("message" to (commit.description ?: ""))
                 turtle {
                     turtleLoad
                 }

--- a/src/main/kotlin/org/openmbee/flexo/sysmlv2/apis/TagApi.kt
+++ b/src/main/kotlin/org/openmbee/flexo/sysmlv2/apis/TagApi.kt
@@ -36,8 +36,9 @@ fun FlexoModelHandler.tagFromResponse(
     outgoing: Map<Property, Set<RDFNode>>,
     projectId: String,
     tagId: String
-): Tag {
-    val commit = Identified(outgoing[MMS.commit]!!.resource()!!.uri.uriSuffix)
+): Tag? {
+    val commitSuffix = outgoing[MMS.commit]?.resource()?.uri?.uriSuffix ?: return null
+    val commit = Identified(commitSuffix)
     return Tag(
         atId = tagId,
         atType = Tag.AtType.Tag,
@@ -73,7 +74,7 @@ fun Route.TagApi() {
         val tag = patchResponse.parseModel {
             model.listSubjectsWithProperty(RDF.type, MMS.Lock).mapWith {
                 tagFromResponse(it.outgoing(), path.projectId, it.uri.uriSuffix)
-            }.toList().firstOrNull()
+            }.toList().filterNotNull().firstOrNull()
         } ?: return@delete call.respond(HttpStatusCode.NotFound)
         call.respond(tag)
     }
@@ -90,7 +91,7 @@ fun Route.TagApi() {
         val tags = flexoResponse.parseModel {
             model.listSubjectsWithProperty(RDF.type, MMS.Lock).mapWith {
                 tagFromResponse(it.outgoing(), path.projectId, it.uri.uriSuffix)
-            }.toList()
+            }.toList().filterNotNull()
         }
         val tag = tags.firstOrNull() ?: return@get call.respond(HttpStatusCode.NotFound)
         call.respond(tag)
@@ -114,7 +115,7 @@ fun Route.TagApi() {
                 (it.uri.uriSuffix.startsWith("Commit.") || it.hasProperty(SYSMLV2.DELETED))
             }.mapWith {
                 tagFromResponse(it.outgoing(), path.projectId, it.uri.uriSuffix)
-            }.toList()
+            }.toList().filterNotNull()
         })
     }
 
@@ -143,6 +144,7 @@ fun Route.TagApi() {
         }
         call.respond(createTagResponse.parseLdp {
             tagFromResponse(focalOutgoing, projectId, tagId)
+                ?: throw IllegalStateException("Layer1 did not return mms:commit for newly created tag $tagId")
         })
     }
 }


### PR DESCRIPTION
- Failed to list /commits : when replacing fuseki with graphdb. Same data, but GraphDB’s SPARQL optimizer drops wildcard property bindings (?branch_p ?branch_o) from an OPTIONAL block when joined with the access-control BGP — so mms:commit is never returned and sysmlv2 crashes. (last issue we discussed)
commit message never stored on DB. Forward commit message from sysmlv2 payload to layer1 to store it.

- Commit message never stored on DB. Forward commit message from sysmlv2 payload to layer1 to store it.